### PR TITLE
Make scripts by default update testing, not prod

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -113,7 +113,7 @@ const tmpDir = `./tmp`;                         // where zip files are temporari
 const geojsonDir = `./geojson`;                 // where generated newline-delimited GeoJSON files are written
 const regionMappingDir = `./regionMapping`;     // where to find and update regionmapping file and write regionids files
 const tesseraDir = `./tessera`;                 // where to find and update tessera_config.json
-const tileHost = `tiles.terria.io`;
+const tileHost = `tile-test.terria.io`;
 const testCsvDir = './test';
 const mbtilesDir = './mbtiles';
 


### PR DESCRIPTION
This changes where tiles are uploaded to by default and also affects what bucket the produced `regionMapping.json` points to. I think both of these changes are positive, as it's best to play around with layers first in tile-test.terria.io and then `cp -r`/`sync` the folder into tiles.terria.io just before release, at which point you'd update `regionMapping.json` to point to the prod bucket.